### PR TITLE
refactor(frontend): use next-themes library for theming

### DIFF
--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -43,6 +43,7 @@
     "lodash.random": "3.2.0",
     "lodash.shuffle": "4.2.0",
     "next": "14.1.0",
+    "next-themes": "0.3.0",
     "react": "^18",
     "react-colorful": "5.6.1",
     "react-compare-slider": "3.0.1",

--- a/apps/frontend/src/app/global-error.tsx
+++ b/apps/frontend/src/app/global-error.tsx
@@ -1,10 +1,12 @@
 'use client'
 
 import { Button, Flex, Heading, Text, Theme } from '@radix-ui/themes'
+import { ThemeProvider } from 'next-themes'
 import type { Metadata } from 'next'
 
 import { SITE_TITLE } from '@site/config'
-import { getClientThemeAppearance } from '@lib/theme/helpers'
+import { getLocalStorageThemeColor } from '@lib/theme/helpers'
+import { DEFAULT_THEME_COLOR, THEME_LS_KEY } from '@lib/theme'
 import { geistSans } from './fonts'
 import type { ErrorPageProps } from '@app-types/next'
 
@@ -13,51 +15,51 @@ export const metadata: Metadata = {
 }
 
 export default function GlobalError({ error, reset }: ErrorPageProps) {
-  const { theme, themeColor } = getClientThemeAppearance()
+  const themeColor = getLocalStorageThemeColor()
 
   // eslint-disable-next-line no-console
   console.log(error)
 
-  const handleReset = () => reset()
-
   return (
     <html lang='en' suppressHydrationWarning>
       <body className={geistSans.variable}>
-        <Theme accentColor={themeColor} appearance={theme}>
-          <Flex
-            align='center'
-            justify='start'
-            direction='column'
-            gap='4'
-            width='100%'
-            pb='8'
-            height='100dvh'
-            pt='30dvh'
-          >
-            <Flex asChild align='center' direction='column' gap='2'>
-              <article>
-                <Heading as='h1' size='8'>
-                  Something went wrong
-                </Heading>
+        <ThemeProvider storageKey={THEME_LS_KEY}>
+          <Theme accentColor={themeColor ?? DEFAULT_THEME_COLOR}>
+            <Flex
+              align='center'
+              justify='start'
+              direction='column'
+              gap='4'
+              width='100%'
+              pb='8'
+              height='100dvh'
+              pt='30dvh'
+            >
+              <Flex asChild align='center' direction='column' gap='2'>
+                <article>
+                  <Heading as='h1' size='8'>
+                    Something went wrong
+                  </Heading>
 
-                <Text
-                  as='p'
-                  style={{
-                    color: 'var(--gray-a11)'
-                  }}
-                >
-                  Please try reloading the page or try again later.
-                </Text>
-              </article>
-            </Flex>
+                  <Text
+                    as='p'
+                    style={{
+                      color: 'var(--gray-a11)'
+                    }}
+                  >
+                    Please try reloading the page or try again later.
+                  </Text>
+                </article>
+              </Flex>
 
-            <Flex align='center' justify='between' gap='3'>
-              <Button size='3' radius='large' onClick={handleReset}>
-                Try again
-              </Button>
+              <Flex align='center' justify='between' gap='3'>
+                <Button size='3' radius='large' onClick={reset}>
+                  Try again
+                </Button>
+              </Flex>
             </Flex>
-          </Flex>
-        </Theme>
+          </Theme>
+        </ThemeProvider>
       </body>
     </html>
   )

--- a/apps/frontend/src/app/layout.tsx
+++ b/apps/frontend/src/app/layout.tsx
@@ -1,13 +1,13 @@
 import dynamic from 'next/dynamic'
 import { Analytics } from '@vercel/analytics/react'
 import { SpeedInsights } from '@vercel/speed-insights/next'
-import { Flex, Theme as RadixTheme } from '@radix-ui/themes'
+import { Theme } from '@radix-ui/themes'
+import { ThemeProvider } from 'next-themes'
 import type { Metadata } from 'next'
 import type { PropsWithChildren } from 'react'
 import 'yet-another-react-lightbox/styles.css'
 
 import { Layout } from '@layouts/default'
-import { getThemeAppearance } from '@lib/theme'
 import {
   pathForSocial,
   SITE_DESCRIPTION,
@@ -15,6 +15,7 @@ import {
   SITE_KEYWORDS,
   SITE_TITLE
 } from '@site/config'
+import { DEFAULT_THEME, DEFAULT_THEME_COLOR, getThemeColorCookie, THEME_LS_KEY } from '@lib/theme'
 import { geistSans } from './fonts'
 import './globals.css'
 
@@ -102,20 +103,23 @@ export const metadata: Metadata = {
 }
 
 export default async function RootLayout({ children }: PropsWithChildren) {
-  const { theme, themeColor } = await getThemeAppearance()
+  const themeColor = await getThemeColorCookie()
 
   return (
-    <html lang='en' className={theme}>
+    <html lang='en' suppressHydrationWarning>
       <body className={geistSans.variable}>
-        <RadixTheme accentColor={themeColor} appearance={theme}>
-          <CookieConsentBanner />
+        <ThemeProvider
+          attribute='class'
+          defaultTheme={DEFAULT_THEME}
+          storageKey={THEME_LS_KEY}
+          disableTransitionOnChange
+        >
+          <Theme accentColor={themeColor ?? DEFAULT_THEME_COLOR}>
+            <CookieConsentBanner />
 
-          <Flex align='center' justify='start' direction='column'>
-            <Layout theme={theme} themeColor={themeColor}>
-              {children}
-            </Layout>
-          </Flex>
-        </RadixTheme>
+            <Layout>{children}</Layout>
+          </Theme>
+        </ThemeProvider>
 
         <Analytics debug={false} />
         <SpeedInsights debug={false} />

--- a/apps/frontend/src/components/AppearancePopover/AppearancePopover.tsx
+++ b/apps/frontend/src/components/AppearancePopover/AppearancePopover.tsx
@@ -1,12 +1,11 @@
 'use client'
 
 import dynamic from 'next/dynamic'
-import { type FC, useState } from 'react'
+import { type CSSProperties, useState } from 'react'
 import { IconButton, Popover, Skeleton } from '@radix-ui/themes'
 
 import { MixerHorizontalIcon } from '@ui/icons/MixerHorizontalIcon'
 import { useSyncThemeAppearance } from '@hooks/useSyncThemeAppearance'
-import type { ThemeProps } from '@lib/theme'
 
 const AppearancePopoverContent = dynamic(
   () => import('./AppearancePopoverContent').then(mod => mod.AppearancePopoverContent),
@@ -16,15 +15,20 @@ const AppearancePopoverContent = dynamic(
   }
 )
 
-const AppearancePopover: FC<ThemeProps> = props => {
+const triggerStyle: CSSProperties = {
+  width: '20px',
+  height: '20px'
+} as const
+
+const AppearancePopover = () => {
   const [isOpen, setIsOpen] = useState(false)
 
-  useSyncThemeAppearance(props)
+  useSyncThemeAppearance()
 
   return (
     <Popover.Root open={isOpen} defaultOpen={false} onOpenChange={setIsOpen}>
       <Popover.Trigger>
-        <IconButton size='3' color='gray' variant='ghost'>
+        <IconButton color='gray' radius='large' variant='ghost' style={triggerStyle}>
           <MixerHorizontalIcon
             color='gray'
             width='16px'
@@ -34,9 +38,7 @@ const AppearancePopover: FC<ThemeProps> = props => {
         </IconButton>
       </Popover.Trigger>
 
-      <Popover.Content sideOffset={3}>
-        {isOpen && <AppearancePopoverContent {...props} />}
-      </Popover.Content>
+      <Popover.Content sideOffset={3}>{isOpen && <AppearancePopoverContent />}</Popover.Content>
     </Popover.Root>
   )
 }

--- a/apps/frontend/src/components/AppearancePopover/AppearancePopoverContent.tsx
+++ b/apps/frontend/src/components/AppearancePopover/AppearancePopoverContent.tsx
@@ -1,23 +1,21 @@
 import { Flex, Separator } from '@radix-ui/themes'
-import type { FC } from 'react'
 
-import { AppearancePopoverTitle } from './AppearancePopoverTitle'
-import { ButtonToggleTheme } from '@components/theme/ButtonToggleTheme'
+import ButtonToggleTheme from '@components/theme/ButtonToggleTheme'
 import { ThemeColorGrid } from '@components/theme/ThemeColorGrid'
-import type { ThemeProps } from '@lib/theme'
+import { AppearancePopoverTitle } from './AppearancePopoverTitle'
 
-export const AppearancePopoverContent: FC<ThemeProps> = ({ theme, themeColor }) => (
+export const AppearancePopoverContent = () => (
   <Flex direction='column' align='start' gap='3' width='170px'>
     <Flex align='center' justify='between' width='100%'>
       <AppearancePopoverTitle title='Theme' />
-      <ButtonToggleTheme theme={theme} />
+      <ButtonToggleTheme />
     </Flex>
 
     <Separator size='4' />
 
     <Flex direction='column' width='100%'>
       <AppearancePopoverTitle title='Theme Color' mb='3' />
-      <ThemeColorGrid themeColor={themeColor} />
+      <ThemeColorGrid />
     </Flex>
   </Flex>
 )

--- a/apps/frontend/src/components/AppearancePopover/AppearancePopoverSkeleton.tsx
+++ b/apps/frontend/src/components/AppearancePopover/AppearancePopoverSkeleton.tsx
@@ -1,8 +1,0 @@
-import { IconButton, Skeleton } from '@radix-ui/themes'
-
-const size = '32px'
-export const AppearancePopoverSkeleton = () => (
-  <Skeleton width={size} height={size} m='-8px'>
-    <IconButton radius='large' />
-  </Skeleton>
-)

--- a/apps/frontend/src/components/AppearancePopover/index.ts
+++ b/apps/frontend/src/components/AppearancePopover/index.ts
@@ -1,2 +1,1 @@
 export { default } from './AppearancePopover'
-export { AppearancePopoverSkeleton } from './AppearancePopoverSkeleton'

--- a/apps/frontend/src/components/theme/ButtonToggleTheme.tsx
+++ b/apps/frontend/src/components/theme/ButtonToggleTheme.tsx
@@ -5,47 +5,49 @@ import type { CSSProperties } from 'react'
 
 import { MoonIcon } from '@ui/icons/MoonIcon'
 import { SunIcon } from '@ui/icons/SunIcon'
-import { setThemeCookie, type Theme, THEME_LS_KEY, type ThemeProps } from '@lib/theme'
+import { useTheme } from '@hooks/useTheme'
+import type { Theme } from '@lib/theme'
 import type { StyleProps } from '@app-types/StyleProps'
 import type { ClassNameProps } from '@app-types/ClassNameProps'
 
 function getThemeIcon(theme: Theme) {
-  const Icon = theme === 'dark' ? MoonIcon : SunIcon
-  const iconLabel = theme === 'dark' ? 'dark theme' : 'light theme'
+  let Icon
+  let iconLabel
+
+  if (theme === 'system') {
+    const isPreferredDark = window.matchMedia('(prefers-color-scheme: dark)').matches
+
+    Icon = isPreferredDark ? MoonIcon : SunIcon
+    iconLabel = isPreferredDark ? 'set light theme' : 'set dark theme'
+  } else {
+    Icon = theme === 'dark' ? MoonIcon : SunIcon
+    iconLabel = theme === 'dark' ? 'set light theme' : 'set dark theme'
+  }
 
   return <Icon width='18px' height='18px' label={iconLabel} />
 }
 
-const style: CSSProperties = {
+const basicStyle: CSSProperties = {
   width: '20px',
   height: '20px'
 } as const
 
-export function ButtonToggleTheme({ theme, className }: Props) {
-  const toggleTheme = () => {
-    const newTheme = theme === 'dark' ? 'light' : 'dark'
-
-    localStorage.setItem(THEME_LS_KEY, newTheme)
-    const event = new StorageEvent('storage', {
-      key: THEME_LS_KEY,
-      newValue: newTheme
-    })
-    window.dispatchEvent(event)
-
-    void setThemeCookie(newTheme)
-  }
+export default function ButtonToggleTheme({ className, style }: ClassNameProps & StyleProps) {
+  const { theme, toggleTheme } = useTheme()
 
   return (
     <IconButton
       variant='ghost'
+      radius='large'
       color='gray'
-      style={style}
+      style={{
+        ...basicStyle,
+        ...style
+      }}
       className={className}
       onClick={toggleTheme}
     >
-      {getThemeIcon(theme)}
+      {getThemeIcon(theme as Theme)}
     </IconButton>
   )
 }
-
-type Props = Pick<ThemeProps, 'theme'> & ClassNameProps & StyleProps

--- a/apps/frontend/src/components/theme/ThemeColorGrid/ThemeColorGrid.tsx
+++ b/apps/frontend/src/components/theme/ThemeColorGrid/ThemeColorGrid.tsx
@@ -2,22 +2,27 @@ import { Grid } from '@radix-ui/themes'
 import type { FC } from 'react'
 
 import { ThemeColorGridItem } from './ThemeColorGridItem'
-import { type GridProps, themeColorItems, type ThemeProps } from '@lib/theme'
+import { type GridProps, themeColorItems } from '@lib/theme'
+import { useTheme } from '@hooks/useTheme'
 
-export const ThemeColorGrid: FC<Props> = ({ themeColor, rows = 4, ...props }) => (
-  <Grid
-    columns={Math.floor(themeColorItems.length / rows).toString()}
-    justify='center'
-    gap='2'
-    width='100%'
-    {...props}
-  >
-    {themeColorItems.map(({ key, color }) => (
-      <ThemeColorGridItem key={key} isSelected={themeColor === color} color={color} />
-    ))}
-  </Grid>
-)
+export const ThemeColorGrid: FC<Props> = ({ rows = 4, ...props }) => {
+  const { themeColor } = useTheme()
 
-interface Props extends Pick<ThemeProps, 'themeColor'>, Omit<GridProps, 'rows'> {
+  return (
+    <Grid
+      columns={Math.floor(themeColorItems.length / rows).toString()}
+      justify='center'
+      gap='2'
+      width='100%'
+      {...props}
+    >
+      {themeColorItems.map(({ key, color }) => (
+        <ThemeColorGridItem key={key} isSelected={themeColor === color} color={color} />
+      ))}
+    </Grid>
+  )
+}
+
+interface Props extends Omit<GridProps, 'rows'> {
   rows?: number
 }

--- a/apps/frontend/src/components/theme/ThemeColorMenu/ThemeColorMenu.tsx
+++ b/apps/frontend/src/components/theme/ThemeColorMenu/ThemeColorMenu.tsx
@@ -6,35 +6,45 @@ import type { FC } from 'react'
 
 import { ColorSwatch } from '@ui/ColorSwatch'
 import { PaletteIcon } from '@ui/icons/PaletteIcon'
-import { getRadixColorVar, setThemeColorCookie, themeColorItems, type ThemeProps } from '@lib/theme'
+import { useTheme } from '@hooks/useTheme'
+import { getRadixColorVar, setThemeColorCookie, themeColorItems } from '@lib/theme'
 import styles from './ThemeColorMenu.module.css'
 
-export const ThemeColorMenu: FC<Props> = ({ themeColor, triggerClassName, contentClassName }) => (
-  <DropdownMenu.Root>
-    <DropdownMenu.Trigger>
-      <IconButton color='gray' variant='ghost' className={clsx(styles.trigger, triggerClassName)}>
-        <PaletteIcon width='20px' height='20px' />
-      </IconButton>
-    </DropdownMenu.Trigger>
+export const ThemeColorMenu: FC<Props> = ({ triggerClassName, contentClassName }) => {
+  const { themeColor } = useTheme()
 
-    <DropdownMenu.Content className={clsx(styles.content, contentClassName)}>
-      <DropdownMenu.Label>Theme Color</DropdownMenu.Label>
-      {/* @typescript-eslint/ban-ts-comment
+  return (
+    <DropdownMenu.Root>
+      <DropdownMenu.Trigger>
+        <IconButton
+          color='gray'
+          radius='large'
+          variant='ghost'
+          className={clsx(styles.trigger, triggerClassName)}
+        >
+          <PaletteIcon width='20px' height='20px' />
+        </IconButton>
+      </DropdownMenu.Trigger>
+
+      <DropdownMenu.Content className={clsx(styles.content, contentClassName)}>
+        <DropdownMenu.Label>Theme Color</DropdownMenu.Label>
+        {/* @typescript-eslint/ban-ts-comment
           @ts-ignore */}
-      <DropdownMenu.RadioGroup value={themeColor} onValueChange={setThemeColorCookie}>
-        {themeColorItems.map(({ key, color }) => (
-          <DropdownMenu.RadioItem key={key} value={color}>
-            <Text className={styles.itemText}>{color}</Text>
+        <DropdownMenu.RadioGroup value={themeColor} onValueChange={setThemeColorCookie}>
+          {themeColorItems.map(({ key, color }) => (
+            <DropdownMenu.RadioItem key={key} value={color}>
+              <Text className={styles.itemText}>{color}</Text>
 
-            <ColorSwatch color={getRadixColorVar(color, 9)} />
-          </DropdownMenu.RadioItem>
-        ))}
-      </DropdownMenu.RadioGroup>
-    </DropdownMenu.Content>
-  </DropdownMenu.Root>
-)
+              <ColorSwatch color={getRadixColorVar(color, 9)} />
+            </DropdownMenu.RadioItem>
+          ))}
+        </DropdownMenu.RadioGroup>
+      </DropdownMenu.Content>
+    </DropdownMenu.Root>
+  )
+}
 
-interface Props extends Pick<ThemeProps, 'themeColor'> {
+interface Props {
   triggerClassName?: string
   contentClassName?: string
 }

--- a/apps/frontend/src/hooks/useSelectedPath.ts
+++ b/apps/frontend/src/hooks/useSelectedPath.ts
@@ -2,14 +2,9 @@
 
 import { usePathname } from 'next/navigation'
 
-import { PATH_ROOT } from '@site/paths'
+import { isPathSelected } from '@helpers/isPathSelected'
 
 export function useSelectedPath(href: string) {
   const pathname = usePathname()
-
-  if (href === PATH_ROOT) {
-    return pathname === href
-  }
-
-  return pathname === href || pathname.startsWith(href)
+  return isPathSelected(pathname, href)
 }

--- a/apps/frontend/src/hooks/useSyncThemeAppearance.ts
+++ b/apps/frontend/src/hooks/useSyncThemeAppearance.ts
@@ -1,35 +1,19 @@
-import {useEffect} from 'react'
+'use client'
 
+import { useEffect } from 'react'
+
+import { useTheme } from '@hooks/useTheme'
 import {
   setThemeColorCookie,
-  setThemeCookie,
   THEME_COLOR_LS_KEY,
-  THEME_LS_KEY,
   type ThemeColor,
-  themeColorItems,
-  type ThemeProps
+  themeColorItems
 } from '@lib/theme'
 
-/**
- * Sync theme appearance between browser windows
- * @param theme - current theme from cookies (on server)
- * @param themeColor - current theme color from cookies (on server)
- */
-export function useSyncThemeAppearance({ theme, themeColor }: ThemeProps) {
+export function useSyncThemeAppearance() {
+  const { theme, themeColor } = useTheme()
+
   useEffect(() => {
-    function handleChangeTheme(ev: StorageEvent) {
-      if (ev.key !== THEME_LS_KEY) return
-
-      const newTheme = ev.newValue
-      if (!newTheme) return
-      const isValidTheme = newTheme === 'light' || newTheme === 'dark'
-      if (!isValidTheme) return
-
-      if (theme !== newTheme) {
-        void setThemeCookie(newTheme)
-      }
-    }
-
     function handleChangeThemeColor(ev: StorageEvent) {
       if (ev.key !== THEME_COLOR_LS_KEY) return
 
@@ -45,11 +29,9 @@ export function useSyncThemeAppearance({ theme, themeColor }: ThemeProps) {
       }
     }
 
-    window.addEventListener('storage', handleChangeTheme)
     window.addEventListener('storage', handleChangeThemeColor)
 
     return () => {
-      window.removeEventListener('storage', handleChangeTheme)
       window.removeEventListener('storage', handleChangeThemeColor)
     }
   }, [theme, themeColor])

--- a/apps/frontend/src/hooks/useTheme.ts
+++ b/apps/frontend/src/hooks/useTheme.ts
@@ -1,0 +1,29 @@
+import { useCallback } from 'react'
+import { useTheme as useNextTheme } from 'next-themes'
+import type { UseThemeProps } from 'next-themes/dist/types'
+
+import { getLocalStorageThemeColor, type ThemeColor } from '@lib/theme'
+
+export function useTheme(): Returns {
+  const { theme, setTheme, ...themeRest } = useNextTheme()
+  const themeColor = getLocalStorageThemeColor()
+
+  const toggleTheme = useCallback(() => {
+    const newTheme = theme === 'dark' ? 'light' : 'dark'
+
+    setTheme(newTheme)
+  }, [theme, setTheme])
+
+  return {
+    ...themeRest,
+    theme,
+    themeColor,
+    setTheme,
+    toggleTheme
+  }
+}
+
+interface Returns extends UseThemeProps {
+  themeColor: ThemeColor | null
+  toggleTheme: VoidFunction
+}

--- a/apps/frontend/src/layouts/default/Layout.tsx
+++ b/apps/frontend/src/layouts/default/Layout.tsx
@@ -1,13 +1,14 @@
-import { Box } from '@radix-ui/themes'
+import { Box, Flex } from '@radix-ui/themes'
 import type { FC, PropsWithChildren } from 'react'
 
 import { LayoutHeader } from './LayoutHeader'
 import { TanStackQueryProvider } from '@lib/tanstack-query'
-import type { ThemeProps } from '@lib/theme'
 
-export const Layout: FC<PropsWithChildren<ThemeProps>> = ({ children, ...props }) => (
-  <Box width='100%' pt='8'>
-    <LayoutHeader {...props} />
-    <TanStackQueryProvider>{children}</TanStackQueryProvider>
-  </Box>
+export const Layout: FC<PropsWithChildren> = ({ children }) => (
+  <Flex align='center' direction='column'>
+    <Box width='100%' pt='8'>
+      <LayoutHeader />
+      <TanStackQueryProvider>{children}</TanStackQueryProvider>
+    </Box>
+  </Flex>
 )

--- a/apps/frontend/src/layouts/default/LayoutHeader/ButtonGithub.tsx
+++ b/apps/frontend/src/layouts/default/LayoutHeader/ButtonGithub.tsx
@@ -1,11 +1,17 @@
 import { IconButton, Tooltip } from '@radix-ui/themes'
+import type { CSSProperties } from 'react'
 
 import { GithubLogoIcon } from '@ui/icons/GithubLogoIcon'
 import { GITHUB_REPO_PATH } from '@site/config'
 
+const style: CSSProperties = {
+  width: '20px',
+  height: '20px'
+} as const
+
 export const ButtonGithub = () => (
   <Tooltip content='Watch the project on GitHub'>
-    <IconButton asChild size='3' color='gray' variant='ghost'>
+    <IconButton asChild radius='large' color='gray' variant='ghost' style={style}>
       <a target='_blank' rel='noreferrer' href={GITHUB_REPO_PATH}>
         <GithubLogoIcon width='16px' height='16px' />
       </a>

--- a/apps/frontend/src/layouts/default/LayoutHeader/LayoutHeader.tsx
+++ b/apps/frontend/src/layouts/default/LayoutHeader/LayoutHeader.tsx
@@ -1,31 +1,32 @@
 import dynamic from 'next/dynamic'
 import { Flex } from '@radix-ui/themes'
-import type { FC } from 'react'
 
 import { AppLogo } from '@ui/AppLogo'
-import { NavigationDesktop } from './navigation/NavigationDesktop'
-import { AppearancePopoverSkeleton } from '@components/AppearancePopover'
 import { ButtonGithub } from './ButtonGithub'
-import { ButtonToggleTheme } from '@components/theme/ButtonToggleTheme'
+import { NavigationDesktop } from './navigation/NavigationDesktop'
 import { ThemeColorMenu } from '@components/theme/ThemeColorMenu'
-import type { ThemeProps } from '@lib/theme'
+import { IconButtonGhostSkeleton } from '@ui/skeletons/IconButtonGhostSkeleton'
 import styles from './LayoutHeader.module.css'
 
 const AppearancePopover = dynamic(() => import('@components/AppearancePopover'), {
   ssr: false,
-  loading: () => <AppearancePopoverSkeleton />
+  loading: () => <IconButtonGhostSkeleton />
 })
 const NavigationDrawer = dynamic(() => import('./navigation/NavigationDrawer'), {
   ssr: false
 })
+const ButtonToggleTheme = dynamic(() => import('@components/theme/ButtonToggleTheme'), {
+  ssr: false,
+  loading: () => <IconButtonGhostSkeleton />
+})
 
 // TODO: Optimize components imports and rendering
-export const LayoutHeader: FC<ThemeProps> = themeProps => (
+export const LayoutHeader = () => (
   <Flex asChild align='center' justify='between' width='100%' px='4' py='2' className={styles.root}>
     <header>
       <div className={styles.themeMobileActions}>
-        <ButtonToggleTheme {...themeProps} />
-        <ThemeColorMenu themeColor={themeProps.themeColor} />
+        <ButtonToggleTheme />
+        <ThemeColorMenu />
       </div>
 
       <AppLogo className={styles.logo} />
@@ -35,7 +36,7 @@ export const LayoutHeader: FC<ThemeProps> = themeProps => (
 
         <Flex align='center' gap='4'>
           <ButtonGithub />
-          <AppearancePopover {...themeProps} />
+          <AppearancePopover />
         </Flex>
       </div>
 

--- a/apps/frontend/src/lib/helpers/isPathSelected.ts
+++ b/apps/frontend/src/lib/helpers/isPathSelected.ts
@@ -1,0 +1,9 @@
+import { PATH_ROOT } from '@site/paths'
+
+export function isPathSelected(pathname: string, href: string) {
+  if (href === PATH_ROOT) {
+    return pathname === href
+  }
+
+  return pathname === href || pathname.startsWith(href)
+}

--- a/apps/frontend/src/lib/helpers/isServer.ts
+++ b/apps/frontend/src/lib/helpers/isServer.ts
@@ -1,0 +1,1 @@
+export const isServer = () => typeof window === 'undefined'

--- a/apps/frontend/src/lib/theme/actions.ts
+++ b/apps/frontend/src/lib/theme/actions.ts
@@ -2,35 +2,9 @@
 
 import { cookies } from 'next/headers'
 
-import {
-  DEFAULT_THEME,
-  DEFAULT_THEME_COLOR,
-  THEME_COLOR_COOKIE_NAME,
-  THEME_COOKIE_NAME
-} from './constants'
-import { validateTheme, validateThemeColor } from './helpers'
-import type { Theme, ThemeColor } from './types'
-
-export async function setThemeCookie(value: Theme): Promise<void> {
-  const cookieStore = cookies()
-  cookieStore.set(THEME_COOKIE_NAME, value)
-}
-
-export async function getThemeCookie(): Promise<Theme | null> {
-  const cookieStore = cookies()
-
-  const theme = cookieStore.get(THEME_COOKIE_NAME)
-  if (!theme) {
-    return null
-  }
-
-  const isThemeValid = validateTheme(theme.value as Theme)
-  if (!isThemeValid) {
-    return null
-  }
-
-  return theme.value as Theme
-}
+import { validateThemeColor } from './helpers'
+import { THEME_COLOR_COOKIE_NAME } from './constants'
+import type { ThemeColor } from './types'
 
 export async function setThemeColorCookie(value: ThemeColor): Promise<void> {
   const cookieStore = cookies()
@@ -51,14 +25,4 @@ export async function getThemeColorCookie(): Promise<ThemeColor | null> {
   }
 
   return themeColor.value as ThemeColor
-}
-
-export async function getThemeAppearance() {
-  const theme = await getThemeCookie()
-  const themeColor = await getThemeColorCookie()
-
-  return {
-    theme: theme ?? DEFAULT_THEME,
-    themeColor: themeColor ?? DEFAULT_THEME_COLOR
-  }
 }

--- a/apps/frontend/src/lib/theme/constants.ts
+++ b/apps/frontend/src/lib/theme/constants.ts
@@ -1,7 +1,7 @@
 import type { Theme, ThemeColor } from './types'
 
 // Defaults
-export const DEFAULT_THEME: Theme = 'light'
+export const DEFAULT_THEME: Theme = 'system'
 export const DEFAULT_THEME_COLOR: ThemeColor = 'indigo'
 
 // Storages

--- a/apps/frontend/src/lib/theme/helpers.ts
+++ b/apps/frontend/src/lib/theme/helpers.ts
@@ -1,3 +1,4 @@
+import { isServer } from '@helpers/isServer'
 import { themeColorSchema, themeSchema } from './schemas'
 import { DEFAULT_THEME, DEFAULT_THEME_COLOR, THEME_COLOR_LS_KEY, THEME_LS_KEY } from './constants'
 import type { Theme, ThemeColor } from './types'
@@ -7,6 +8,10 @@ export const validateThemeColor = (themeColor: ThemeColor) =>
   themeColorSchema.isValidSync(themeColor)
 
 export function getLocalStorageTheme(): Theme | null {
+  if (isServer()) {
+    return null
+  }
+
   const theme = localStorage.getItem(THEME_LS_KEY) as Theme | null
   if (!theme) {
     return null
@@ -21,6 +26,10 @@ export function getLocalStorageTheme(): Theme | null {
 }
 
 export function getLocalStorageThemeColor(): ThemeColor | null {
+  if (isServer()) {
+    return null
+  }
+
   const themeColor = localStorage.getItem(THEME_COLOR_LS_KEY) as ThemeColor | null
   if (!themeColor) {
     return null

--- a/apps/frontend/src/lib/theme/schemas.ts
+++ b/apps/frontend/src/lib/theme/schemas.ts
@@ -2,7 +2,7 @@ import { string } from 'yup'
 
 import { themeColorItems } from './radix/appearance'
 
-export const themeSchema = string().oneOf(['light', 'dark']).defined()
+export const themeSchema = string().oneOf(['light', 'dark', 'system']).defined()
 
 export const themeColorSchema = string()
   .oneOf(themeColorItems.map(item => item.color))

--- a/apps/frontend/src/lib/theme/types.ts
+++ b/apps/frontend/src/lib/theme/types.ts
@@ -2,14 +2,9 @@ import type { RadixThemeColor as ThemeColor } from './radix/types'
 
 export type { ThemeColor }
 
-export type Theme = 'light' | 'dark'
+export type Theme = 'light' | 'dark' | 'system'
 
 export interface ThemeColorItem {
   key: string
   color: ThemeColor
-}
-
-export interface ThemeProps {
-  theme: Theme
-  themeColor: ThemeColor
 }

--- a/apps/frontend/src/lib/ui/skeletons/IconButtonGhostSkeleton.tsx
+++ b/apps/frontend/src/lib/ui/skeletons/IconButtonGhostSkeleton.tsx
@@ -1,0 +1,11 @@
+import { IconButton, Skeleton } from '@radix-ui/themes'
+import type { FC } from 'react'
+
+import type { ButtonProps } from '@lib/theme'
+
+const size = '20px'
+export const IconButtonGhostSkeleton: FC<Pick<ButtonProps, 'radius'>> = ({ radius = 'large' }) => (
+  <Skeleton width={size} height={size}>
+    <IconButton variant='ghost' radius={radius} />
+  </Skeleton>
+)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -213,6 +213,9 @@ importers:
       next:
         specifier: 14.1.0
         version: 14.1.0(@babel/core@7.24.1)(react-dom@18.2.0)(react@18.2.0)
+      next-themes:
+        specifier: 0.3.0
+        version: 0.3.0(react-dom@18.2.0)(react@18.2.0)
       react:
         specifier: ^18
         version: 18.2.0
@@ -319,6 +322,18 @@ importers:
       vitest:
         specifier: 1.1.3
         version: 1.1.3(@types/node@20.11.29)(@vitest/ui@1.2.1)(jsdom@23.2.0)
+
+  libs/react-icons:
+    dependencies:
+      '@radix-ui/react-accessible-icon':
+        specifier: 1.0.3
+        version: 1.0.3(@types/react-dom@18.2.22)(@types/react@18.2.67)(react-dom@18.2.0)(react@18.2.0)
+      '@types/react':
+        specifier: ^18
+        version: 18.2.67
+      react:
+        specifier: ^18
+        version: 18.2.0
 
   libs/sharp: {}
 
@@ -7993,6 +8008,16 @@ packages:
       next: 14.1.0(@babel/core@7.24.1)(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
     dev: true
+
+  /next-themes@0.3.0(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-/QHIrsYpd6Kfk7xakK4svpDI5mmXP0gfvCoJdGpZQ2TOrQZmsW0QxjaiLn8wbIKjtm4BTSqLoix4lxYYOnLJ/w==}
+    peerDependencies:
+      react: ^16.8 || ^17 || ^18
+      react-dom: ^16.8 || ^17 || ^18
+    dependencies:
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    dev: false
 
   /next@14.1.0(@babel/core@7.24.1)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-wlzrsbfeSU48YQBjZhDzOwhWhGsy+uQycR8bHAOt1LY1bn3zZEcDyHQOEoN3aWzQ8LHCAJ1nqrWCc9XF2+O45Q==}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a system theme option, allowing the app to adapt to the system's preferred theme automatically.
	- Added dynamic theme switching based on system preference.
	- Enhanced theme color selection with a new `ThemeColorMenu` component.
	- Implemented a new `useTheme` hook for better theme management across the app.

- **Improvements**
	- Refined theme management and error handling in the `GlobalError` component.
	- Updated the `RootLayout` and `Layout` components for improved theme handling.
	- Streamlined appearance settings with updates to the `AppearancePopover` and its content.
	- Improved layout styling in various components with the introduction of `Flex` from `@radix-ui/themes`.

- **Refactor**
	- Refactored theme-related logic across the app, removing obsolete functions and props.
	- Simplified theme and theme color retrieval to enhance performance and user experience.
	- Modularized path selection logic with the `isPathSelected` helper function.

- **Bug Fixes**
	- Fixed issues related to theme switching and appearance settings to ensure a consistent user experience.

- **Documentation**
	- Added documentation for new utilities like `isServer` to check the runtime environment.

- **Chores**
	- Updated default theme setting to 'system' for aligning with new theme management approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->